### PR TITLE
Update JupyterLab extension packaging and setup

### DIFF
--- a/instrmcp/extensions/jupyterlab/install.json
+++ b/instrmcp/extensions/jupyterlab/install.json
@@ -1,5 +1,5 @@
 {
   "packageManager": "python",
-  "packageName": "mcp_active_cell_bridge",
-  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package mcp_active_cell_bridge"
+  "packageName": "instrmcp",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package instrmcp"
 }

--- a/instrmcp/extensions/jupyterlab/mcp_active_cell_bridge/__init__.py
+++ b/instrmcp/extensions/jupyterlab/mcp_active_cell_bridge/__init__.py
@@ -1,0 +1,8 @@
+"""MCP Active Cell Bridge - JupyterLab Extension
+
+This package contains the JupyterLab extension for bridging active cell content
+between the Jupyter frontend and the InstrMCP server.
+"""
+
+# Package metadata
+__version__ = "0.1.0"

--- a/instrmcp/setup_utils.py
+++ b/instrmcp/setup_utils.py
@@ -11,44 +11,26 @@ from jupyter_core.paths import jupyter_config_dir
 
 
 def setup_jupyter_extension():
-    """Install JupyterLab extension only."""
+    """Build JupyterLab to include the extension."""
     try:
-        # Get the path to the extension package (not the labextension subdirectory)
-        package_dir = Path(__file__).parent
-        extension_path = package_dir / "extensions" / "jupyterlab"
-        
-        if not extension_path.exists():
-            print(f"❌ Extension not found at: {extension_path}")
-            return False
-        
-        print("🔧 Installing JupyterLab extension...")
-        
-        # Install the extension in development mode
-        result = subprocess.run([
-            "jupyter", "labextension", "develop", str(extension_path), "--overwrite"
+        print("🔧 Extension is automatically installed via pip...")
+        print("🔨 Building JupyterLab with extension...")
+
+        # Build JupyterLab to include the extension
+        # The extension is already installed via pip install, just need to rebuild
+        build_result = subprocess.run([
+            "jupyter", "lab", "build", "--minimize=False"
         ], capture_output=True, text=True)
-        
-        if result.returncode == 0:
-            print("✅ JupyterLab extension installed successfully")
-            
-            # Build JupyterLab to include the extension
-            print("🔨 Building JupyterLab with extension...")
-            build_result = subprocess.run([
-                "jupyter", "lab", "build", "--minimize=False"
-            ], capture_output=True, text=True)
-            
-            if build_result.returncode == 0:
-                print("✅ JupyterLab built successfully")
-                return True
-            else:
-                print(f"⚠️  JupyterLab build failed: {build_result.stderr}")
-                return False
+
+        if build_result.returncode == 0:
+            print("✅ JupyterLab built successfully")
+            return True
         else:
-            print(f"❌ Failed to install extension: {result.stderr}")
+            print(f"⚠️  JupyterLab build failed: {build_result.stderr}")
             return False
-            
+
     except Exception as e:
-        print(f"❌ Error installing JupyterLab extension: {e}")
+        print(f"❌ Error building JupyterLab: {e}")
         return False
 
 


### PR DESCRIPTION
Changed install.json to reference the correct package name 'instrmcp' and updated uninstall instructions. Added __init__.py for the mcp_active_cell_bridge extension with version metadata. Refactored setup_utils.py to simplify the JupyterLab extension setup process, removing the explicit labextension develop step and relying on pip installation and JupyterLab build.