### PR TITLE
notebook_execute_code: bridge-independent kernel execution (#29)

### DIFF
--- a/instrmcp/servers/jupyter_qcodes/backend/notebook_unsafe.py
+++ b/instrmcp/servers/jupyter_qcodes/backend/notebook_unsafe.py
@@ -426,6 +426,202 @@ class NotebookUnsafeBackend(BaseBackend):
                 "error": str(e),
             }
 
+    async def execute_code(
+        self, code: str, timeout: float = 30.0
+    ) -> Dict[str, Any]:
+        """Execute a code string directly on the kernel, bypassing the frontend.
+
+        Bridge-independent execution route (instrMCP#29). The code is sent to the
+        kernel as a normal ZMQ ``execute_request`` via a loopback
+        ``jupyter_client`` connected to the kernel's own connection file — the
+        same shell-channel path the JupyterLab frontend uses, and the one a
+        Qt-integrated kernel (``%gui qt``) actually services. This avoids both the
+        frontend active-cell comm (which fails when the bridge degrades) and an
+        asyncio callback on the kernel loop (which an idle Qt loop does not pump).
+
+        Args:
+            code: Python source to execute on the kernel.
+            timeout: Max seconds to wait for completion (default 30). 0 =
+                fire-and-forget (send and return immediately, e.g. long sweeps).
+
+        Returns:
+            Dict with execution status and captured stdout/result/error.
+        """
+        import threading
+
+        # Fire-and-forget: send the request on a daemon thread and return at once.
+        if not timeout or timeout <= 0:
+            threading.Thread(
+                target=self._exec_via_kernel_client,
+                args=(code, None),
+                daemon=True,
+            ).start()
+            return self._exec_no_wait_result()
+
+        loop = asyncio.get_running_loop()
+        try:
+            # The client call blocks; run it in a worker thread. Outer guard is a
+            # safety net for a hung wait_for_ready (execute itself self-times-out).
+            return await asyncio.wait_for(
+                loop.run_in_executor(None, self._exec_via_kernel_client, code, timeout),
+                timeout + 10.0,
+            )
+        except (asyncio.TimeoutError, TimeoutError):
+            return {
+                "success": True,
+                "executed": True,
+                "status": "timeout",
+                "has_error": False,
+                "has_output": False,
+                "message": f"Timeout after {timeout}s waiting for execution to complete",
+            }
+
+    def _exec_via_kernel_client(
+        self, code: str, timeout: Optional[float]
+    ) -> Dict[str, Any]:
+        """Run ``code`` on THIS kernel via a loopback jupyter_client (blocking).
+
+        Sends a ZMQ execute_request on the kernel's shell channel and collects
+        stdout/result/error from IOPub. Call from a worker thread.
+        """
+        from ipykernel import get_connection_file
+        from jupyter_client import BlockingKernelClient
+
+        outs: Dict[str, Any] = {
+            "stdout": [],
+            "stderr": [],
+            "result": None,
+            "error": None,
+        }
+
+        def _hook(msg):
+            try:
+                mt = msg.get("header", {}).get("msg_type")
+                c = msg.get("content", {})
+                if mt == "stream":
+                    key = "stderr" if c.get("name") == "stderr" else "stdout"
+                    outs[key].append(c.get("text", ""))
+                elif mt == "execute_result":
+                    outs["result"] = c.get("data", {}).get("text/plain")
+                elif mt == "error":
+                    outs["error"] = (
+                        c.get("ename"),
+                        c.get("evalue"),
+                        c.get("traceback", []),
+                    )
+            except Exception:  # never let output handling kill the execution
+                pass
+
+        kc = BlockingKernelClient(connection_file=get_connection_file())
+        kc.load_connection_file()
+        kc.start_channels()
+        try:
+            kc.wait_for_ready(timeout=10.0)
+            try:
+                reply = kc.execute_interactive(
+                    code,
+                    timeout=timeout,
+                    output_hook=_hook,
+                    store_history=True,
+                    allow_stdin=False,
+                )
+            except TimeoutError:
+                # The execute_request was sent and the kernel keeps running it
+                # (e.g. a long sweep); we just stopped waiting.
+                return {
+                    "success": True,
+                    "executed": True,
+                    "status": "timeout",
+                    "has_error": False,
+                    "has_output": bool("".join(outs["stdout"])),
+                    "stdout": "".join(outs["stdout"]),
+                    "message": f"Timeout after {timeout}s waiting for execution to complete",
+                }
+            return self._assemble_kernel_result(reply.get("content", {}), outs, code)
+        finally:
+            try:
+                kc.stop_channels()
+            except Exception:
+                pass
+
+    def _assemble_kernel_result(
+        self, content: Dict[str, Any], outs: Dict[str, Any], code: str
+    ) -> Dict[str, Any]:
+        """Build the execute_code result dict from a kernel execute_reply + IOPub.
+
+        Pure (no I/O) so it is unit-testable independent of a live kernel.
+        """
+        status = content.get("status", "ok")
+        exec_count = content.get("execution_count", 0)
+        stdout = "".join(outs.get("stdout", []))
+
+        err = outs.get("error")
+        if status == "error" or err:
+            ename, evalue, tb = err or (
+                content.get("ename"),
+                content.get("evalue"),
+                content.get("traceback", []),
+            )
+            return {
+                "success": True,
+                "executed": True,
+                "status": "error",
+                "has_error": True,
+                "error_type": ename or "Error",
+                "error_message": evalue or "",
+                "traceback": "\n".join(tb) if isinstance(tb, list) else str(tb),
+                "stdout": stdout,
+                "has_output": bool(stdout),
+                "execution_count": exec_count,
+            }
+
+        result: Dict[str, Any] = {
+            "success": True,
+            "executed": True,
+            "status": "completed",
+            "has_error": False,
+            "has_output": bool(stdout),
+            "stdout": stdout,
+            "execution_count": exec_count,
+        }
+        if outs.get("result") is not None:
+            result["result"] = outs["result"]
+
+        # Detect a started MeasureIt sweep (same heuristic as execute_editing_cell).
+        sweep_matches = re.findall(r"(\w+)\.start\s*\(", code)
+        if sweep_matches:
+            result["sweep_detected"] = True
+            result["sweep_names"] = sweep_matches
+            if len(sweep_matches) == 1:
+                result["suggestion"] = (
+                    f"A sweep appears to have been started. Use "
+                    f"measureit_wait_for_sweep with sweep name "
+                    f"'{sweep_matches[0]}' to wait for completion."
+                )
+            else:
+                names = ", ".join(f"'{n}'" for n in sweep_matches)
+                result["suggestion"] = (
+                    f"Multiple sweeps appear to have been started ({names}). "
+                    f"Use measureit_wait_for_sweep(timeout=..., variable_name=name) or "
+                    f"measureit_wait_for_sweep(timeout=..., all=True) to wait for completion."
+                )
+
+        return result
+
+    def _exec_no_wait_result(self) -> Dict[str, Any]:
+        """Fire-and-forget result for execute_code (timeout=0)."""
+        return {
+            "success": True,
+            "executed": True,
+            "status": "no_wait",
+            "has_error": False,
+            "has_output": False,
+            "message": (
+                "Execution scheduled (fire-and-forget). Use "
+                "measureit_wait_for_sweep / notebook_kernel_status to check progress."
+            ),
+        }
+
     async def add_new_cell(
         self,
         cell_type: str = "code",

--- a/instrmcp/servers/jupyter_qcodes/core/notebook_unsafe_tools.py
+++ b/instrmcp/servers/jupyter_qcodes/core/notebook_unsafe_tools.py
@@ -209,9 +209,131 @@ class UnsafeToolRegistrar:
     def register_all(self):
         """Register all unsafe mode tools."""
         self._register_execute_active_cell()
+        self._register_execute_code()
         self._register_add_cell()
         self._register_delete_cell()
         self._register_apply_patch()
+
+    def _register_execute_code(self):
+        """Register the notebook/execute_code tool.
+
+        Bridge-independent execution route (instrMCP#29): runs a passed code
+        string directly on the kernel, bypassing the JupyterLab frontend
+        active-cell comm. Use this when the notebook frontend bridge is
+        degraded (add_cell/execute_active_cell timing out) but the kernel is
+        still alive.
+        """
+
+        @self.mcp.tool(
+            name="notebook_execute_code",
+            annotations={
+                "readOnlyHint": False,
+                "destructiveHint": False,
+                "idempotentHint": False,
+                "openWorldHint": True,
+            },
+        )
+        async def execute_code(
+            code: str, timeout: float = 30.0, detailed: bool = False
+        ) -> List[TextContent]:
+            """Execute a code string directly on the running kernel.
+
+            Bypasses the JupyterLab frontend bridge (no cell is added to the
+            notebook) — the code runs on the kernel main thread with the same
+            semantics as a normal cell. Use this to recover when notebook_add_cell
+            / notebook_execute_active_cell time out but the kernel is alive.
+
+            Args:
+                code: Python source to execute on the kernel.
+                timeout: Max seconds to wait for completion (default 30). 0 =
+                    fire-and-forget (schedule and return immediately).
+                detailed: If false (default), omit the verbose traceback field.
+
+            Returns: {success, status (completed|error|timeout|no_wait), stdout,
+                execution_count, has_error/has_output, error_* on error,
+                sweep_detected/sweep_names/suggestion if a sweep was started}.
+            """
+            # SECURITY: scan the PASSED code before consent (hard boundary).
+            # Unlike execute_active_cell, no frontend round-trip is needed to get
+            # the code — it is passed directly, so this works even when the
+            # frontend bridge is dead.
+            rejection = self._scan_and_reject(code, "notebook_execute_code")
+            if rejection:
+                return rejection
+
+            # Request consent if a consent manager is configured.
+            if self.consent_manager:
+                try:
+                    consent_result = await self.consent_manager.request_consent(
+                        operation="execute_code",
+                        tool_name="notebook_execute_code",
+                        author="MCP Server",
+                        details={
+                            "source_code": code,
+                            "description": (
+                                "Execute a code string directly on the kernel "
+                                "(bypasses the JupyterLab frontend bridge)"
+                            ),
+                        },
+                    )
+                    if not consent_result["approved"]:
+                        reason = consent_result.get("reason", "User declined")
+                        logger.warning(f"execute_code declined - {reason}")
+                        return [
+                            TextContent(
+                                type="text",
+                                text=json.dumps(
+                                    {
+                                        "success": False,
+                                        "error": f"Execution declined: {reason}",
+                                    },
+                                    indent=2,
+                                ),
+                            )
+                        ]
+                except TimeoutError:
+                    logger.error("Consent request timed out for execute_code")
+                    return [
+                        TextContent(
+                            type="text",
+                            text=json.dumps(
+                                {
+                                    "success": False,
+                                    "error": "Consent request timed out",
+                                },
+                                indent=2,
+                            ),
+                        )
+                    ]
+
+            start = time.perf_counter()
+            try:
+                result = await self.tools.execute_code(code, timeout=timeout)
+                duration = (time.perf_counter() - start) * 1000
+                log_tool_call(
+                    "notebook_execute_code",
+                    {"timeout": timeout, "detailed": detailed},
+                    duration,
+                    "success",
+                )
+                if not detailed and isinstance(result, dict):
+                    result = {k: v for k, v in result.items() if k != "traceback"}
+                return [
+                    TextContent(
+                        type="text", text=json.dumps(result, indent=2, default=str)
+                    )
+                ]
+            except Exception as e:
+                duration = (time.perf_counter() - start) * 1000
+                log_tool_call(
+                    "notebook_execute_code", {}, duration, "error", str(e)
+                )
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"success": False, "error": str(e)}, indent=2),
+                    )
+                ]
 
     def _register_execute_active_cell(self):
         """Register the notebook/execute_active_cell tool."""

--- a/instrmcp/servers/jupyter_qcodes/tools.py
+++ b/instrmcp/servers/jupyter_qcodes/tools.py
@@ -238,6 +238,10 @@ class QCodesReadOnlyTools:
         """Execute the currently editing cell and wait for output."""
         return await self._notebook_unsafe.execute_editing_cell(timeout)
 
+    async def execute_code(self, code: str, timeout: float = 30.0) -> Dict[str, Any]:
+        """Execute a code string directly on the kernel (bypasses the frontend bridge)."""
+        return await self._notebook_unsafe.execute_code(code, timeout)
+
     async def add_new_cell(
         self,
         cell_type: str = "code",

--- a/tests/unit/servers/test_execute_code.py
+++ b/tests/unit/servers/test_execute_code.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for notebook_execute_code — the bridge-independent kernel execution
+route (instrMCP#29). The code is sent to the kernel as a ZMQ execute_request via
+a loopback jupyter_client; here we test the pure result assembly and the
+execute_code control flow. The live-kernel client path is covered by the e2e.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from instrmcp.servers.jupyter_qcodes.tools import QCodesReadOnlyTools
+
+
+def make_backend():
+    ip = MagicMock()
+    ip.user_ns = {}
+    ip.execution_count = 0
+    return QCodesReadOnlyTools(ip)._notebook_unsafe
+
+
+# ---- pure result assembly (_assemble_kernel_result) ----
+
+def test_assemble_completed_with_stdout():
+    b = make_backend()
+    r = b._assemble_kernel_result(
+        {"status": "ok", "execution_count": 7},
+        {"stdout": ["42\n"], "stderr": [], "result": None, "error": None},
+        "print(42)",
+    )
+    assert r["status"] == "completed"
+    assert r["has_error"] is False
+    assert r["has_output"] is True
+    assert r["stdout"] == "42\n"
+    assert r["execution_count"] == 7
+
+
+def test_assemble_error_from_iopub():
+    b = make_backend()
+    r = b._assemble_kernel_result(
+        {"status": "error", "execution_count": 3},
+        {"stdout": [], "stderr": [], "result": None,
+         "error": ("ValueError", "boom", ["tb-line-1", "tb-line-2"])},
+        "raise ValueError('boom')",
+    )
+    assert r["status"] == "error"
+    assert r["has_error"] is True
+    assert r["error_type"] == "ValueError"
+    assert r["error_message"] == "boom"
+    assert "tb-line-1" in r["traceback"]
+
+
+def test_assemble_detects_sweep():
+    b = make_backend()
+    r = b._assemble_kernel_result(
+        {"status": "ok", "execution_count": 1},
+        {"stdout": [], "stderr": [], "result": None, "error": None},
+        "sweep.start()",
+    )
+    assert r["sweep_detected"] is True
+    assert "sweep" in r["sweep_names"]
+    assert "measureit_wait_for_sweep" in r["suggestion"]
+
+
+def test_assemble_includes_result_value():
+    b = make_backend()
+    r = b._assemble_kernel_result(
+        {"status": "ok", "execution_count": 2},
+        {"stdout": [], "stderr": [], "result": "99", "error": None},
+        "x",
+    )
+    assert r["result"] == "99"
+
+
+# ---- execute_code control flow (kernel client mocked) ----
+
+@pytest.mark.asyncio
+async def test_execute_code_returns_kernel_client_result(monkeypatch):
+    tools = QCodesReadOnlyTools(MagicMock(user_ns={}, execution_count=0))
+    canned = {
+        "success": True, "executed": True, "status": "completed",
+        "has_error": False, "has_output": True, "stdout": "hi\n",
+        "execution_count": 5,
+    }
+    monkeypatch.setattr(
+        tools._notebook_unsafe, "_exec_via_kernel_client",
+        lambda code, timeout: canned,
+    )
+    result = await tools.execute_code("print('hi')", timeout=5.0)
+    assert result == canned
+
+
+@pytest.mark.asyncio
+async def test_execute_code_fire_and_forget_returns_no_wait(monkeypatch):
+    tools = QCodesReadOnlyTools(MagicMock(user_ns={}, execution_count=0))
+    monkeypatch.setattr(
+        tools._notebook_unsafe, "_exec_via_kernel_client",
+        lambda code, timeout: None,
+    )
+    result = await asyncio.wait_for(tools.execute_code("x = 1", timeout=0), timeout=2.0)
+    assert result["executed"] is True
+    assert result["status"] == "no_wait"

--- a/tests/unit/servers/test_unsafe_execute_code_tool.py
+++ b/tests/unit/servers/test_unsafe_execute_code_tool.py
@@ -1,0 +1,99 @@
+"""
+Unit tests for the notebook_execute_code unsafe tool registration
+(bridge-independent kernel execution, instrMCP#29).
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from instrmcp.servers.jupyter_qcodes.core.notebook_unsafe_tools import (
+    UnsafeToolRegistrar,
+)
+
+
+def make_mcp():
+    mcp = MagicMock()
+    mcp._tools = {}
+
+    def tool_decorator(name=None, annotations=None, **kwargs):
+        def wrapper(func):
+            mcp._tools[name or func.__name__] = func
+            return func
+
+        return wrapper
+
+    mcp.tool = tool_decorator
+    return mcp
+
+
+def make_tools():
+    tools = MagicMock()
+    tools.execute_code = AsyncMock(
+        return_value={
+            "success": True,
+            "executed": True,
+            "status": "completed",
+            "has_output": True,
+            "stdout": "42\n",
+            "execution_count": 7,
+        }
+    )
+    return tools
+
+
+def test_registers_notebook_execute_code_tool():
+    mcp = make_mcp()
+    UnsafeToolRegistrar(mcp, make_tools(), consent_manager=None).register_all()
+    assert "notebook_execute_code" in mcp._tools
+
+
+@pytest.mark.asyncio
+async def test_safe_code_delegates_to_execute_code():
+    mcp = make_mcp()
+    tools = make_tools()
+    UnsafeToolRegistrar(mcp, tools, consent_manager=None).register_all()
+
+    blocks = await mcp._tools["notebook_execute_code"](code="print(42)", timeout=5.0)
+
+    tools.execute_code.assert_awaited_once()
+    args, kwargs = tools.execute_code.call_args
+    passed_code = kwargs.get("code", args[0] if args else None)
+    assert passed_code == "print(42)"
+    payload = json.loads(blocks[0].text)
+    assert payload["status"] == "completed"
+    assert payload["stdout"] == "42\n"
+
+
+@pytest.mark.asyncio
+async def test_dangerous_code_rejected_before_execution():
+    mcp = make_mcp()
+    tools = make_tools()
+    UnsafeToolRegistrar(mcp, tools, consent_manager=None).register_all()
+
+    blocks = await mcp._tools["notebook_execute_code"](
+        code="import os; os.system('rm -rf /')", timeout=5.0
+    )
+
+    tools.execute_code.assert_not_called()
+    payload = json.loads(blocks[0].text)
+    assert payload.get("blocked") is True or payload.get("success") is False
+
+
+@pytest.mark.asyncio
+async def test_declined_consent_blocks_execution():
+    mcp = make_mcp()
+    tools = make_tools()
+    consent = MagicMock()
+    consent.request_consent = AsyncMock(
+        return_value={"approved": False, "reason": "User declined"}
+    )
+    UnsafeToolRegistrar(mcp, tools, consent_manager=consent).register_all()
+
+    blocks = await mcp._tools["notebook_execute_code"](code="print(1)", timeout=5.0)
+
+    consent.request_consent.assert_awaited_once()
+    tools.execute_code.assert_not_called()
+    payload = json.loads(blocks[0].text)
+    assert payload["success"] is False


### PR DESCRIPTION
## Summary

Adds a new unsafe tool **`notebook_execute_code`** that runs a passed code string **directly on the kernel with no JupyterLab frontend round-trip** — the deterministic recovery path #29 asked for. When the frontend comm bridge degrades, every existing execution route (`notebook_execute_active_cell`, the database auto-execute) goes through the frontend active-cell API and fails; this one does not.

## Mechanism

Sends the code as a normal **ZMQ `execute_request`** via a loopback `jupyter_client` connected to the kernel's own connection file — the same shell-channel path the frontend uses, and (crucially) the one a **Qt-integrated kernel (`%gui qt`, used by MeasureIt) actually services**.

Two simpler approaches were tried and rejected (documented in the code):
- sync `ip.run_cell` from the kernel io_loop → **deadlocks** (nested running loop);
- `run_cell_async` via `run_coroutine_threadsafe` on the kernel loop → the coroutine is scheduled but **never pumped**: under `%gui qt` the kernel's asyncio loop is dormant while idle and only wakes on ZMQ traffic (confirmed empirically — queued coroutines all fired at once the moment unrelated ZMQ activity arrived).

Captures stdout/result/error from IOPub, advances `execution_count`, detects a started MeasureIt sweep (suggests `measureit_wait_for_sweep`), and supports `timeout` / fire-and-forget (`timeout=0`). Security: the passed code is scanned and consent-gated exactly like `notebook_execute_active_cell` — but with **no frontend round-trip for the scan**, so it works even when the bridge is dead.

## Tests

- **10 unit tests**: pure result assembly (`_assemble_kernel_result`: completed/error/sweep/result-value) + `execute_code` control flow (delegation, fire-and-forget).
- **e2e against a real kernel + headless frontend — 8/8 checks**, including the key one:

| check | result |
|---|---|
| execute_code completes on real kernel (stdout, exec_count) | ✅ |
| shares the kernel namespace across calls | ✅ |
| **add_cell FAILS with the frontend killed** (2s timeout) | ✅ |
| **execute_code STILL runs with the frontend killed** | ✅ |

## Scope

Addresses the **bridge-independent-execution** ask of #29 (complements the listener-leak fix in #30). Follow-ups: serialize the frontend comm handlers, bridge health-check/auto-recovery. Consumer-side resilience is caidish/qdevBot#53 — once this lands, the qdevBot doom-loop reminder can suggest `notebook_execute_code` as the recovery action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)